### PR TITLE
Fix code scanning alert no. 7: SQL query built from user-controlled sources

### DIFF
--- a/api.py
+++ b/api.py
@@ -34,8 +34,8 @@ def search():
     conn = sqlite3.connect("data.db")
     c = conn.cursor()
     try:
-        statement = "select * from data where data='" + code + "'"
-        c.execute(statement)
+        statement = "select * from data where data=?"
+        c.execute(statement, (code,))
         found = c.fetchall()
         if found == []:
             return f"Invalid Code<br>{statement}"


### PR DESCRIPTION
Fixes [https://github.com/anhkhoa14592/sql-injection-demo/security/code-scanning/7](https://github.com/anhkhoa14592/sql-injection-demo/security/code-scanning/7)

To fix the problem, we need to use parameterized queries instead of directly concatenating user input into the SQL query string. Parameterized queries ensure that user input is properly escaped and treated as data rather than executable code.

- Replace the direct concatenation of the `code` parameter into the SQL query string with a parameterized query.
- Use the `?` placeholder for the parameter in the SQL query and pass the `code` parameter as a tuple to the `execute` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
